### PR TITLE
chore(deps): bump to python:3.9-slim

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # For more information, please refer to https://aka.ms/vscode-docker-python
-FROM python:3.8-slim
+FROM python:3.9-slim
 
 EXPOSE 5001
 


### PR DESCRIPTION
flask[async] (as of Flask 3.x) requires Python >= 3.9